### PR TITLE
changes for chap 18

### DIFF
--- a/app/src/main/res/values-es-w600dp/strings.xml
+++ b/app/src/main/res/values-es-w600dp/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crime_title_hint">Introduzca un título significativo y memorable para el crimen.</string>
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">IntentoCriminal</string>
+    <string name="crime_title_hint">Introduzca un título para el crimen.</string>
+    <string name="crime_title_label">Título</string>
+    <string name="crime_details_label">Detalles</string>
+    <string name="crime_solved_label">Solucionado</string>
+    <string name="date_picker_title">Fecha del crimen:</string>
+    <string name="new_crime">Crimen Nuevo</string>
+    <string name="show_subtitle">Mostrar Subtítulos</string>
+    <string name="hide_subtitle">Esconder Subtítulos</string>
+    <string name="subtitle_format">%1$s crímenes</string>
+    <string name="crime_suspect_text">Elegir Sospechoso</string>
+    <string name="crime_report_text">Enviar el Informe del Crimen</string>
+    <string name="crime_report">%1$s!
+        El crimen fue descubierto el %2$s. %3$s, y %4$s
+    </string>
+    <string name="crime_report_solved">El caso está resuelto</string>
+    <string name="crime_report_unsolved">El caso no está resuelto</string>
+    <string name="crime_report_no_suspect">no hay sospechoso.</string>
+    <string name="crime_report_suspect">el/la sospechoso/a es %s.</string>
+    <string name="crime_report_subject">IntentoCriminal Informe del Crimen</string>
+    <string name="send_report">Enviar el informe del crimen a través de</string>
+</resources>

--- a/app/src/main/res/values-w600dp/strings.xml
+++ b/app/src/main/res/values-w600dp/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crime_title_hint">Enter a meaningful, memorable title for the crime.</string>
+</resources>


### PR DESCRIPTION
This PR has changes for Chapter 18:
- Localization of resources in Spanish
- Specifying a longer crime title string for spanish devices with `available width>600dp`
- This demonstrates how default resource resolution works in Android.